### PR TITLE
Removing command that causes entrypont failure

### DIFF
--- a/templates/rgon-proxy/0/docker-compose.yml
+++ b/templates/rgon-proxy/0/docker-compose.yml
@@ -51,4 +51,3 @@ services:
       RGEN_CONFIG_ONETIME: '/etc/rancher-gen/default/rancher-gen-onetime.cfg'
       ACME_EMAIL: ${ACME_EMAIL}
       ACME_API: ${ACME_API}
-    command: "-config /etc/rancher-gen/default/rancher-gen.cfg"


### PR DESCRIPTION
An error is thrown on startup:

```
[ENTRYPOINT]: Rancher-Gen first-run complete
/app/entrypoint.sh: exec: line 75: -config: not found
```

This happens because `docker-compose.yml` sends a command through to override the Dockerfile command specified at https://github.com/CausticLab/rgon-proxy/blob/dev/Dockerfile#L35. 

Now that we run `entrypoint.sh` instead of directly running `rancher-gen`, we can omit the command here.