### PR TITLE
FIX readme rgon.redirect label suggestion

### DIFF
--- a/templates/rgon-proxy/README.md
+++ b/templates/rgon-proxy/README.md
@@ -7,4 +7,4 @@ Related containers can be defined with following labels:
 - `rgon.domain=mydomain.com`
 - `rgon.port=80`
 - `rgon.ssl='true'`
-- `rgon.redirect='https'`
+- `rgon.redirect=https`


### PR DESCRIPTION
It works ok with rgon.redirect=https and not with "rgon.redirect='https'